### PR TITLE
.travis.yml: update following move to GHA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 os: linux
-dist: xenial
+dist: focal
 language: python
 cache: pip
 arch: amd64
 
 python:
-    - "3.6"
-    - "3.7"
-    - "3.8"
+    - "3.9"
 
 env:
       AVOCADO_LOG_DEBUG=yes
@@ -28,22 +26,7 @@ script:
 
 jobs:
   include:
-    - name: "Code Coverage"
-      python: "3.8"
-      arch: amd64
-      env:
-        - SELF_CHECK_CONTINUOUS=yes
-        - CC_TEST_REPORTER_ID=387887b88a76f31c2c376219fc749689ea5975c8fe7fcd9609f1dcc139e053a6
-      install:
-        - pip install -r requirements-selftests.txt
-        - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-        - chmod +x ./cc-test-reporter
-        - ./cc-test-reporter before-build
-      script:
-        - make develop && ./selftests/run_coverage
-      after_script:
-        - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
-    - python: "3.8"
+    - python: "3.9"
       arch: s390x
       env:
         - AVOCADO_PARALLEL_LINT_JOBS=1
@@ -52,7 +35,7 @@ jobs:
       # Disable pip cache dir temporarily
       install:
        - pip install --no-cache-dir -r requirements-selftests.txt
-    - python: "3.8"
+    - python: "3.9"
       arch: ppc64le
       env:
         - AVOCADO_PARALLEL_LINT_JOBS=1
@@ -61,7 +44,7 @@ jobs:
       # Disable pip cache dir temporarily
       install:
        - pip install --no-cache-dir -r requirements-selftests.txt
-    - python: "3.8"
+    - python: "3.9"
       arch: arm64
       env:
         - AVOCADO_PARALLEL_LINT_JOBS=1
@@ -70,7 +53,3 @@ jobs:
       # Disable pip cache dir temporarily
       install:
        - pip install --no-cache-dir -r requirements-selftests.txt
-
-  allow_failures:
-    - python: "nightly"
-    - name: "Ad hoc checks on OS X"


### PR DESCRIPTION
Update distribution from Xenial LTS (16.06) to Focal LTS (20.04).
Update to Python 3.9
Only leave non-amd64 builds: arm64, ppc64le and s390x

Signed-off-by: Ana Guerrero Lopez <anguerre@redhat.com>