### PR TITLE
utils/vmimage: use cloud.debian.org for Debian

### DIFF
--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -304,8 +304,7 @@ class DebianImageProvider(ImageProviderBase):
 
     name = 'Debian'
 
-    def __init__(self, version='[0-9]+.[0-9]+.[0-9]+.*', build=None,
-                 arch=DEFAULT_ARCH):
+    def __init__(self, version='[a-z]+', build='[0-9]+', arch=DEFAULT_ARCH):
         # Debian uses 'amd64' instead of 'x86_64'
         if arch == 'x86_64':
             arch = 'amd64'
@@ -314,9 +313,10 @@ class DebianImageProvider(ImageProviderBase):
             arch = 'arm64'
 
         super(DebianImageProvider, self).__init__(version, build, arch)
-        self.url_versions = 'https://cdimage.debian.org/cdimage/openstack/'
-        self.url_images = self.url_versions + '{version}/'
-        self.image_pattern = 'debian-(?P<version>{version})-openstack-(?P<arch>{arch}).qcow2$'
+        # Debian likes codenames
+        self.url_versions = 'https://cloud.debian.org/images/cloud/'
+        self.url_images = self.url_versions + '{version}/latest/'
+        self.image_pattern = 'debian-(?P<build>{build})-generic-(?P<arch>{arch}).qcow2$'
 
 
 class JeosImageProvider(ImageProviderBase):

--- a/selftests/pre_release/tests/vmimage.py.data/variants.yml
+++ b/selftests/pre_release/tests/vmimage.py.data/variants.yml
@@ -37,10 +37,12 @@ distro: !mux
     x86_64:
       arch: amd64
     version: !mux
-      9.13.28:
-        version: 9.13.28-20211002
-      10.11.0:
-        version: 10.11.0
+      # Debian 10 is codenamed buster
+      buster:
+        version: buster
+      # Debian 11 is codenamed bullseye
+      bullseye:
+        version: bullseye
   fedora:
     name: fedora
     !filter-out : /run/architectures/arm

--- a/selftests/unit/utils/test_vmimage.py
+++ b/selftests/unit/utils/test_vmimage.py
@@ -117,89 +117,134 @@ class DebianImageProvider(unittest.TestCase):
     VERSION_LISTING = """<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
 <html>
  <head>
-  <title>Index of /cdimage/openstack</title>
+  <title>Index of /images/cloud</title>
   <link rel="stylesheet" href="/layout/autoindex.css" type="text/css">
 <meta name="viewport" content="width=device-width, initial-scale=1"> </head>
  <body>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<title>Debian Official Cloud Images for OpenStack -- Getting Debian  - www.debian.org</title>
+<title>Debian Official Cloud Images -- Getting Debian  - www.debian.org</title>
 <link rel="author" href="mailto:webmaster@debian.org">
 <link href="https://www.debian.org/debian.css" rel="stylesheet" type="text/css">
 <link href="https://www.debian.org/debian-en.css" rel="stylesheet" type="text/css" media="all">
 
+
 <div id="header">
-    <div id="upperheader">
-        <div id="logo">
-            <a href="https://www.debian.org/" title="Debian Home"><img src="https://www.debian.org/Pics/openlogo-50.png" alt="Debian" width="50" height="61"></a>
-        </div> <!-- end logo -->
-        <div id="navbar">
-            <p class="hidecss"><a href="#content">Skip Quicknav</a></p>
-            <ul>
-                <li><a href="https://www.debian.org/intro/about">About Debian</a></li>
-                <li><a href="https://www.debian.org/distrib/">Getting Debian</a></li>
-                <li><a href="https://www.debian.org/support">Support</a></li>
-                <li><a href="https://www.debian.org/devel/">Developers' Corner</a></li>
-            </ul>
-        </div> <!-- end navbar -->
-    </div> <!-- end upperheader -->
+  <div id="upperheader">
+    <div id="logo">
+      <a href="https://www.debian.org/" title="Debian Home"><img src="https://www.debian.org/Pics/openlogo-50.png" alt="Debian" width="50" height="61"></a>
+    </div> <!-- end logo -->
+    <div id="navbar">
+      <p class="hidecss"><a href="#content">Skip Quicknav</a></p>
+      <ul>
+        <li><a href="https://www.debian.org/intro/about">About Debian</a></li>
+        <li><a href="https://www.debian.org/distrib/">Getting Debian</a></li>
+        <li><a href="https://www.debian.org/support">Support</a></li>
+        <li><a href="https://www.debian.org/devel/">Developers' Corner</a></li>
+      </ul>
+    </div> <!-- end navbar -->
+  </div> <!-- end upperheader -->
+  <h1>Debian Official Cloud Images</h1>
 
-    <h1>Debian Official Cloud Images for OpenStack</h1>
+  <p>
+    In this page you can find the Debian cloud images provided by the Debian Cloud Team for some cloud providers.
+    End users do not need to download these images, as they are
+    usually provided by their cloud providers.
+    For now we are supporting:
+
+    <ul>
+      <li><i>Amazon EC2 (amd64, arm64; Also see <a href="https://wiki.debian.org/Cloud/AmazonEC2Image">the wiki</a> and the <a href="https://aws.amazon.com/marketplace/seller-profile?id=4d4d4e5f-c474-49f2-8b18-94de9d43e2c0&ref=dtl_B0859NK4HC">AWS Marketplace listing</a></i>)</li>
+      <li><i>Microsoft Azure (amd64; Also see <a href="https://wiki.debian.org/Cloud/MicrosoftAzure">the wiki</a> and <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps?search=debian&page=1">The Azure Marketplace</a></i>)</li>
+      <li><i>OpenStack (amd64, arm64, ppc64el; two
+      flavours <a href="https://cloud.debian.org/cdimage/cloud/OpenStack/">using
+      openstack-debian-images</a> and using the <a href="https://cloud.debian.org/cdimage/cloud/bullseye">toolchain</a> from the
+      cloud team.
+      Also see <a href="https://wiki.debian.org/OpenStack">the wiki</a></i>)</li>
+      <li><i>Plain VM (amd64)</i>, suitable for use with QEMU</li>
+    </ul>
 
 
-    <p>
-    These are files containing cloud images of the Debian GNU/Linux
-    operating system designed for OpenStack.  The files in this
-    directory are specifically for the <code>amd64</code>
-    and <code>arm64</code> architectures.
-    </p>
+    From buster on we provide images for different cloud providers in
+    one directory. There we use file names like this:
 
-    <h2>Will the image work on a cloud platform other than OpenStack?</h2>
+    <ul>
+      <li><tt>debian-11-generic-ppc64el-daily-20210425-618.qcow2</tt></li>
+      <li><tt>debian-11-genericcloud-amd64-daily-20210425-618.qcow2</tt></li>
+      <li><tt>debian-11-ec2-arm64-daily-20210425-618.tar.xz</tt></li>
+    </ul>
 
-    <p>
-    If your platform supports the EC2 style metadata server (which is
-    contacted by cloud-init), and also supports an HDD image (using either
-    raw or qcow2 format), then most likely it will work. Note that it will
-    <strong>not</strong> work on Amazon EC2 if you are not using the
-    HVM mode.
-    </p>
+    <ul>
+  <li><i>azure</i>: Optimized for the Microsoft Azure environment</li>
+  <li><i>ec2</i>: Optimized for the Amazon EC2</li>
+  <li><i>generic</i>: Should run in any environment using cloud-init,
+  for e.g. OpenStack, DigitalOcean and also on bare metal.</li>
+  <li><i>genericcloud</i>: Similar to generic. Should run in any
+  virtualised environment. Is smaller than `generic` by excluding
+  drivers for physical hardware.</li>
+  <li><i>nocloud</i>: Mostly useful for testing the build process
+   itself. Doesn't have cloud-init installed, but instead allows root
+   login without a password. </li>
+   </ul>
 
-    <h2>Where are the Jessie (Debian 8) images?</h2>
+  </p>
 
-    <p>
-    Debian Jessie is no longer supported by the Debian Cloud Team, as
-    official security support for it ended in June 2018. We strongly
-    recommend that users should move on to use Stretch (Debian 9)
-    or Buster (Debian 10) instead, our current supported versions.
-    </p>
+  <h2>How to upload to OpenStack?</h2>
 
-    <p>
-    If you understand the lack of support and still have a strong need
-    for a Jessie image, they are still available for download - see
-    the "archive" directory.
-    </p>
+  <p>Once you have downloaded the image, you would typically need to upload it to
+  Glance, using a command like this one (example for amd64):</p>
 
-    <h2>Other questions?</h2>
+  <pre>openstack image create \
+    --container-format bare \
+    --disk-format qcow2 \
+    --property hw_disk_bus=scsi \
+    --property hw_scsi_model=virtio-scsi \
+    --property os_type=linux \
+    --property os_distro=debian \
+    --property os_admin_user=debian \
+    --property os_version='10.9.1' \
+    --public \
+    --file debian-10-generic-arm64-20210329-591.qcow2 \
+    debian-10-generic-arm64-20210329-591.qcow2</pre>
 
-    <p>
-    Other questions can be forwarded to the OpenStack packaging
-    team: <b>debian-openstack at lists.debian.org</b>.
-    </p>
+  <p>Note that <i>hw_disk_bus=scsi</i> and <i>hw_scsi_model=virtio-scsi</i>
+  select the virtio-scsi driver instead of the virtio-blk, which is nicer
+  (on older versions of Qemu, virtio-blk doesn't have the FSTRIM feature,
+  for example). Also, the properties <i>os_type, os_distro, os_version and
+  os_admin_user</i> are OpenStack standards as per
+  <a href="https://docs.openstack.org/glance/latest/admin/useful-image-properties.html">this
+  document</a>. It is best practice to set them, especialy on public clouds,
+  to allow your cloud users to filter the image list to search what they need,
+  for example using a command like this one:
+
+  <pre>openstack image list --property os_distro=debian</pre>
+
+  <h2>How can I verify my download is correct and exactly what has been
+    created by Debian?</h2>
+
+  <p>There are files (SHA512SUMS, etc.) which contain
+    checksums of the images. These checksum files are also signed - see
+    SHA512SUMS.sign, etc. For more information about the verification steps, read
+    the <a href="https://www.debian.org/CD/verify">verification guide</a>.
+  </p>
+
+  <h2>Other questions?</h2>
+
+  <p>Questions can be forwarded to the Debian Cloud Team: <b>debian-cloud at lists.debian.org</b>.</p>
 
 </div>
   <table id="indexlist">
    <tr class="indexhead"><th class="indexcolicon"><img src="/icons2/blank.png" alt="[ICO]"></th><th class="indexcolname"><a href="?C=N;O=D">Name</a></th><th class="indexcollastmod"><a href="?C=M;O=A">Last modified</a></th><th class="indexcolsize"><a href="?C=S;O=A">Size</a></th></tr>
    <tr class="indexbreakrow"><th colspan="4"><hr></th></tr>
-   <tr class="even"><td class="indexcolicon"><a href="/cdimage/"><img src="/icons2/go-previous.png" alt="[PARENTDIR]"></a></td><td class="indexcolname"><a href="/cdimage/">Parent Directory</a></td><td class="indexcollastmod">&nbsp;</td><td class="indexcolsize">  - </td></tr>
-   <tr class="odd"><td class="indexcolicon"><a href="9.12.0/"><img src="/icons2/folder.png" alt="[DIR]"></a></td><td class="indexcolname"><a href="9.12.0/">9.12.0/</a></td><td class="indexcollastmod">2020-02-09 16:03  </td><td class="indexcolsize">  - </td></tr>
-   <tr class="even"><td class="indexcolicon"><a href="10.3.0/"><img src="/icons2/folder.png" alt="[DIR]"></a></td><td class="indexcolname"><a href="10.3.0/">10.3.0/</a></td><td class="indexcollastmod">2020-02-09 03:02  </td><td class="indexcolsize">  - </td></tr>
-   <tr class="odd"><td class="indexcolicon"><a href="archive/"><img src="/icons2/folder.png" alt="[DIR]"></a></td><td class="indexcolname"><a href="archive/">archive/</a></td><td class="indexcollastmod">2020-02-09 16:10  </td><td class="indexcolsize">  - </td></tr>
-   <tr class="even"><td class="indexcolicon"><a href="current-9/"><img src="/icons2/folder.png" alt="[DIR]"></a></td><td class="indexcolname"><a href="current-9/">current-9/</a></td><td class="indexcollastmod">2020-02-09 16:03  </td><td class="indexcolsize">  - </td></tr>
-   <tr class="odd"><td class="indexcolicon"><a href="current-10/"><img src="/icons2/folder.png" alt="[DIR]"></a></td><td class="indexcolname"><a href="current-10/">current-10/</a></td><td class="indexcollastmod">2020-02-09 03:02  </td><td class="indexcolsize">  - </td></tr>
-   <tr class="even"><td class="indexcolicon"><a href="current/"><img src="/icons2/folder.png" alt="[DIR]"></a></td><td class="indexcolname"><a href="current/">current/</a></td><td class="indexcollastmod">2020-02-09 03:02  </td><td class="indexcolsize">  - </td></tr>
-   <tr class="odd"><td class="indexcolicon"><a href="testing/"><img src="/icons2/folder.png" alt="[DIR]"></a></td><td class="indexcolname"><a href="testing/">testing/</a></td><td class="indexcollastmod">2019-07-08 13:30  </td><td class="indexcolsize">  - </td></tr>
+   <tr class="even"><td class="indexcolicon"><a href="/images/"><img src="/icons2/go-previous.png" alt="[PARENTDIR]"></a></td><td class="indexcolname"><a href="/images/">Parent Directory</a></td><td class="indexcollastmod">&nbsp;</td><td class="indexcolsize">  - </td></tr>
+   <tr class="odd"><td class="indexcolicon"><a href="OpenStack/"><img src="/icons2/folder.png" alt="[DIR]"></a></td><td class="indexcolname"><a href="OpenStack/">OpenStack/</a></td><td class="indexcollastmod">2021-10-10 00:51  </td><td class="indexcolsize">  - </td></tr>
+   <tr class="even"><td class="indexcolicon"><a href="bullseye/"><img src="/icons2/folder.png" alt="[DIR]"></a></td><td class="indexcolname"><a href="bullseye/">bullseye/</a></td><td class="indexcollastmod">2021-10-11 15:47  </td><td class="indexcolsize">  - </td></tr>
+   <tr class="odd"><td class="indexcolicon"><a href="buster-backports/"><img src="/icons2/folder.png" alt="[DIR]"></a></td><td class="indexcolname"><a href="buster-backports/">buster-backports/</a></td><td class="indexcollastmod">2021-10-11 22:06  </td><td class="indexcolsize">  - </td></tr>
+   <tr class="even"><td class="indexcolicon"><a href="buster/"><img src="/icons2/folder.png" alt="[DIR]"></a></td><td class="indexcolname"><a href="buster/">buster/</a></td><td class="indexcollastmod">2021-10-11 22:04  </td><td class="indexcolsize">  - </td></tr>
+   <tr class="odd"><td class="indexcolicon"><a href="sid/"><img src="/icons2/folder.png" alt="[DIR]"></a></td><td class="indexcolname"><a href="sid/">sid/</a></td><td class="indexcollastmod">2019-07-18 10:34  </td><td class="indexcolsize">  - </td></tr>
+   <tr class="even"><td class="indexcolicon"><a href="stretch-backports/"><img src="/icons2/folder.png" alt="[DIR]"></a></td><td class="indexcolname"><a href="stretch-backports/">stretch-backports/</a></td><td class="indexcollastmod">2019-07-18 10:40  </td><td class="indexcolsize">  - </td></tr>
+   <tr class="odd"><td class="indexcolicon"><a href="stretch/"><img src="/icons2/folder.png" alt="[DIR]"></a></td><td class="indexcolname"><a href="stretch/">stretch/</a></td><td class="indexcollastmod">2019-07-18 10:40  </td><td class="indexcolsize">  - </td></tr>
    <tr class="indexbreakrow"><th colspan="4"><hr></th></tr>
 </table>
-<address>Apache/2.4.41 (Unix) Server at cdimage.debian.org Port 443</address>
+<address>Apache/2.4.46 (Unix) Server at cloud.debian.org Port 443</address>
 </body></html>"""
 
     @unittest.mock.patch('avocado.utils.vmimage.urlopen')
@@ -207,7 +252,7 @@ class DebianImageProvider(unittest.TestCase):
         urlread_mocked = unittest.mock.Mock(return_value=self.VERSION_LISTING)
         urlopen_mock.return_value = unittest.mock.Mock(read=urlread_mocked)
         provider = vmimage.DebianImageProvider()
-        self.assertEqual(provider.get_versions(), ['9.12.0', '10.3.0'])
+        self.assertEqual(provider.get_versions(), ['bullseye', 'buster', 'sid', 'stretch'])
 
 
 class OpenSUSEImageProvider(unittest.TestCase):


### PR DESCRIPTION
The Debian project is moving the cloud images to cloud.debian.org
and has now generic images for environment using cloud-init, such
as OpenStack.

Update variants.yml accordingly using codenames.
Remove Debian 9 (stretch) and include instead Debian 11 (bullseye).

Update selftests/unit/utils/test_vmimage.py with the cloud.debian.org
HTML page and corresponding codename checks.

Fixes: https://github.com/avocado-framework/avocado/issues/5029
Signed-off-by: Ana Guerrero Lopez <anguerre@redhat.com>