### PR TITLE
ci.yml: improve codecoverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,10 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.9, 3.10.0]
+        python-version: [3.10.0]
+    env:
+      SELF_CHECK_CONTINUOUS: "yes"
+      CC_TEST_REPORTER_ID: "387887b88a76f31c2c376219fc749689ea5975c8fe7fcd9609f1dcc139e053a6"
 
     steps:
       - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}, runner on ${{ runner.os }}"
@@ -67,24 +70,16 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install and pre script
-        env:
-          SELF_CHECK_CONTINUOUS: "yes"
-          CC_TEST_REPORTER_ID: "387887b88a76f31c2c376219fc749689ea5975c8fe7fcd9609f1dcc139e053a6"
+      - name: Install
         run: |
          pip install -r requirements-dev.txt
          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
          chmod +x ./cc-test-reporter
-         ./cc-test-reporter before-build
+      - name: Run pre script
+        run: ./cc-test-reporter before-build
       - name: Run script
-        env:
-          SELF_CHECK_CONTINUOUS: "yes"
-          CC_TEST_REPORTER_ID: "387887b88a76f31c2c376219fc749689ea5975c8fe7fcd9609f1dcc139e053a6"
         run: make develop && ./selftests/run_coverage
-      - name: post script
-        env:
-          SELF_CHECK_CONTINUOUS: "yes"
-          CC_TEST_REPORTER_ID: "387887b88a76f31c2c376219fc749689ea5975c8fe7fcd9609f1dcc139e053a6"
+      - name: Run post script
         run: ./cc-test-reporter after-build
       - run: echo "🥑 This job's status is ${{ job.status }}."
 


### PR DESCRIPTION
Export variables only once for the full job.

Only run once in latest Python 3.10.0

Split steps to debug faster possible problems:
installation, pre script, script and post script.

Signed-off-by: Ana Guerrero Lopez <anguerre@redhat.com>